### PR TITLE
Close the multiprocessing pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tbats/abstract/Estimator.py
+++ b/tbats/abstract/Estimator.py
@@ -141,6 +141,7 @@ class Estimator(BaseEstimator):
         # note n_jobs = None means to use cpu_count()
         pool = multiprocessing.pool.Pool(processes=self.n_jobs)
         models = pool.map(self._case_fit, components_grid)
+        pool.close()
         self._y = None  # clean-up
         if len(models) == 0:
             return None


### PR DESCRIPTION
This will prevent the open file error from having to many process pools open. It comes up when I have to cross validate and make many models in one for loop.